### PR TITLE
make concurrency safe,修复rpc调用方法并发安全问题

### DIFF
--- a/context_lock/client/client.go
+++ b/context_lock/client/client.go
@@ -34,14 +34,16 @@ func main() {
 	ctx := context.WithValue(context.Background(), share.ReqMetaDataKey, map[string]string{"aaa": "from client"})
 	ctx = context.WithValue(ctx, share.ResMetaDataKey, make(map[string]string))
 	wg := sync.WaitGroup{}
-
+	mu := sync.Mutex{}
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
 
 			args.A = i
+			mu.Lock()
 			err := xclient.Call(ctx, "Mul", args, reply)
+			mu.Unlock()
 			if err != nil {
 				log.Fatalf("failed to call: %v", err)
 			}


### PR DESCRIPTION
rpc调用的Mul方法并不是并发安全的.
涉及的文件
`rpcx-examples/context-lock/server/server.go`
`rpcx-examples/context-lock/client/client.go`
### 修改之前:
启动server
```shell
➜  server git:(make-concurrency-safe) go run server.go
received meta: map[aaa:from client]
received meta: map[aaa:from client]
received meta: map[aaa:from client]
received meta: map[aaa:from client]
received meta: map[aaa:from client]
^Z
[1]  + 92836 suspended  go run server.go
➜  server git:(make-concurrency-safe)
```
启动client,有时正确,有时错误,因为并发不安全
```shell
➜  client git:(make-concurrency-safe) ✗ go run client.go
2024/12/07 16:41:49 89 * 20 = 1780
2024/12/07 16:41:49 received meta: map[__ServerAddress:127.0.0.1:8972 echo:from server]
2024/12/07 16:41:49 89 * 20 = 1780
2024/12/07 16:41:49 received meta: map[__ServerAddress:127.0.0.1:8972 echo:from server]
2024/12/07 16:41:49 89 * 20 = 1780
2024/12/07 16:41:49 89 * 20 = 1780
2024/12/07 16:41:49 received meta: map[__ServerAddress:127.0.0.1:8972 echo:from server]
2024/12/07 16:41:49 89 * 20 = 1780
goroutine 71 [running]:

goroutine 71 [running]:
github.com/smallnest/rpcx/client.(*Client).call(0x140002b0000github.com/smallnest/rpcx/client.(*Client).call(0x140002b0000, {0x100508738, 0x1400039c820}, {0x1003ca48d, , {0x100508738, 0x1400039c820}, {0x1003ca48d, 0x5}, {0x1003ca077, 0x3}, 0x5}, {0x1003ca077, 0x3}, {0x1004736a0, 0x140001822b0}, {0x1004736e0, {0x1004736a0, 0x140001822b0}, {0x1004736e0, ...})
    /Users/pansu/go/pkg/mod/github.com/smallnest/rpcx@v1.8.32/client/client.go:346 +0x7a0
...})
    /Users/pansu/go/pkg/mod/github.com/smallnest/rpcx@v1.8.32/client/client.go:346 +0x7a0
github.com/smallnest/rpcx/client.(*Client).Call(github.com/smallnest/rpcx/client.(*Client).Call(0x140001943a8?, {0x140001943a8?, {0x100508738?, 0x1400039c820?}, {0x1003ca48d?0x100508738?, 0x1400039c820?}, {0x1003ca48d?, 0x5?}, {0x1003ca077?, , 0x5?}, {0x1003ca077?, 0x3?}, {0x1004736a0?, 0x140001822b00x3?}, {0x1004736a0?, 0x140001822b0?}, {0x1004736e0?, ...}?}, {0x1004736e0?, ...})
    /Users/pansu/go/pkg/mod/github.com/smallnest/rpcx@v1.8.32/client/client.go:302 +0x3c
github.com/smallnest/rpcx/client.(*xClient).wrapCall(0x1400019c4e0, {0x1005085e8?, 0x14000197bf0?}, {0x10050c620, 0x140002b0000}, {)
    /Users/pansu/go/pkg/mod/github.com/smallnest/rpcx@v1.8.32/client/client.go:302 +0x3c
github.com/smallnest/rpcx/client.(*xClient).wrapCall(0x1400019c4e0, {0x1005085e8?, 0x14000197bf0?}, {0x10050c620, 0x140002b0000}, {0x1003ca077, 0x3}, {0x1004736a0, 0x140001822b0}0x1003ca077, 0x3}, {0x1004736a0, 0x140001822b0}, {0x1004736e0, ...})
    /Users/pansu/go/pkg/mod/github.com/smallnest/rpcx@v1.8.32/client/xclient.go, {0x1004736e0, ...})
    /Users/pansu/go/pkg/mod/github.com/smallnest/rpcx@v1.8.32/client/xclient.go:890 +0x22c
:890 +0x22c
github.com/smallnest/rpcx/client.(*xClient).Call(0x1400019c4e0, github.com/smallnest/rpcx/client.(*xClient).Call(0x1400019c4e0, {0x1005085e8?, 0x14000197bf0?}, {{0x1005085e8?, 0x14000197bf0?}, {0x1003ca077, 0x3}, {0x1004736a0, 0x140001822b00x1003ca077, 0x3}, {0x1004736a0, 0x140001822b0}, {0x1004736e0, 0x140001822c0})
    }, {0x1004736e0, 0x140001822c0})
    /Users/pansu/go/pkg/mod/github.com/smallnest/rpcx@v1.8.32/client/xclient.go:589 +0xf94
main.main.func1/Users/pansu/go/pkg/mod/github.com/smallnest/rpcx@v1.8.32/client/xclient.go:589 +0xf94
main.main.func1(0x0?)
    /Users/pansu/Projects/Pr/rpcx-examples/context_lock/client/client.go:44 +(0x0?)
    /Users/pansu/Projects/Pr/rpcx-examples/context_lock/client/client.go:44 +0xa0
created by main.main in goroutine 10xa0
created by main.main in goroutine 1
    /Users/pansu/Projects/Pr/rpcx-examples/context_lock/client/client.go:40 +0x31c

    /Users/pansu/Projects/Pr/rpcx-examples/context_lock/client/client.go:40 +0x31c

goroutine 1 [semacquire]:

goroutine 1 [semacquire]:
sync.runtime_Semacquire(0x140000021c0?sync.runtime_Semacquire(0x140000021c0?)
    /usr/local/go/src/runtime/sema.go:71 +0x2c
)
    /usr/local/go/src/runtime/sema.go:71 +0x2c
sync.(*WaitGroup).Wait(0x140001822d0)
sync.(*WaitGroup).Wait(0x140001822d0)
    /usr/local/go/src/sync/waitgroup.go:118 +0x74
main.main    /usr/local/go/src/sync/waitgroup.go:118 +0x74
main.main()
()
    /Users/pansu/Projects/Pr/rpcx-examples/context_lock/client/client.go:54 +0x404
    /Users/pansu/Projects/Pr/rpcx-examples/context_lock/client/client.go:54 +0x404

goroutine 21 [sync.Mutex.Lock]:

goroutine 21 [sync.Mutex.Lock]:
sync.runtime_SemacquireMutex(0x140000261a0?, sync.runtime_SemacquireMutex(0x140000261a0?, 0x14?, 0x20?)
    /usr/local/go/src/runtime/sema.go:0x14?, 0x20?)
    /usr/local/go/src/runtime/sema.go:95 +0x28
sync.(*Mutex).lockSlow(0x14000196420)
95 +0x28
sync.(*Mutex).lockSlow(0x14000196420)
    /usr/local/go/src/sync/mutex.go:173 +0x174
    /usr/local/go/src/sync/mutex.go:173 +0x174
sync.(*Mutex).Lock(...)
sync.(*Mutex).Lock(...)
    /usr/local/go/src/sync/mutex.go:92
    /usr/local/go/src/sync/mutex.go:92
log.(*Logger).output(0x14000196420log.(*Logger).output(0x14000196420, 0x0, 0x2, 0x1400010ef08)
    /usr/local/go/src/log/log.go, 0x0, 0x2, 0x1400010ef08)
    /usr/local/go/src/log/log.go:243 +0x370
:243 +0x370
log.Printf(...)
log.Printf(...)
    /usr/local/go/src/log/log.go:397
main.main.func1(0x0?    /usr/local/go/src/log/log.go:397
main.main.func1(0x0?)
    /Users/pansu/Projects/Pr/rpcx-examples/context_lock/client/client.go:48 +0x18c
created by )
    /Users/pansu/Projects/Pr/rpcx-examples/context_lock/client/client.go:48 +0x18c
created by main.main in goroutine 1
    /Users/pansu/Projects/Pr/rpcx-examples/context_lock/client/client.go:40main.main in goroutine 1
    /Users/pansu/Projects/Pr/rpcx-examples/context_lock/client/client.go:40 +0x31c

goroutine 22 [sync.Mutex.Lock]:
 +0x31c
```
### 修改之后:
启动serevr:
```shell
➜  server git:(make-concurrency-safe) go run server.go
received meta: map[aaa:from client]
received meta: map[aaa:from client]
received meta: map[aaa:from client]
received meta: map[aaa:from client]
received meta: map[aaa:from client]
received meta: map[aaa:from client]
...
```
启动client:

```shell
➜  client git:(make-concurrency-safe) ✗ for i in {1..100}; do
  go run client.go
done > client_log.txt 2>&1
```
查看client_log.txt,rpc调用全部成功
```shell
2024/12/07 16:50:19 86 * 20 = 1720
2024/12/07 16:50:19 received meta: map[__ServerAddress:127.0.0.1:8972 echo:from server]
2024/12/07 16:50:19 86 * 20 = 1720
2024/12/07 16:50:19 received meta: map[__ServerAddress:127.0.0.1:8972 echo:from server]
2024/12/07 16:50:19 86 * 20 = 1720
2024/12/07 16:50:19 received meta: map[__ServerAddress:127.0.0.1:8972 echo:from server]
2024/12/07 16:50:19 86 * 20 = 1720
2024/12/07 16:50:19 received meta: map[__ServerAddress:127.0.0.1:8972 echo:from server]
2024/12/07 16:50:19 86 * 20 = 1720
2024/12/07 16:50:19 received meta: map[__ServerAddress:127.0.0.1:8972 echo:from server]
2024/12/07 16:50:19 86 * 20 = 1720
2024/12/07 16:50:19 received meta: map[__ServerAddress:127.0.0.1:8972 echo:from server]
2024/12/07 16:50:19 86 * 20 = 1720
2024/12/07 16:50:19 received meta: map[__ServerAddress:127.0.0.1:8972 echo:from server]
2024/12/07 16:50:19 86 * 20 = 1720
2024/12/07 16:50:19 received meta: map[__ServerAddress:127.0.0.1:8972 echo:from server]
2024/12/07 16:50:19 86 * 20 = 1720
2024/12/07 16:50:19 received meta: map[__ServerAddress:127.0.0.1:8972 echo:from server]
...
```
所以,简单的加个锁就行了.